### PR TITLE
tela de login separada em duas telas diferente 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation ("androidx.navigation:navigation-compose:2.7.7")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)


### PR DESCRIPTION
Este Pull Request implementa uma reformulação na tela de login, agora dividida em duas etapas para melhorar a experiência do usuário. A primeira tela solicita apenas o e-mail e, após validação, o usuário é encaminhado para a segunda tela, onde insere a senha e finaliza o login. Essa abordagem torna o processo mais intuitivo, reduz a complexidade visual e segue padrões modernos de design de interface.

Também foi mantida e aprimorada a navegação entre as telas de registro e login utilizando NavHost e NavController, permitindo que o usuário navegue livremente entre criar uma conta ou fazer login, com controle de back stack para evitar acúmulo de telas. O estado de cada campo é devidamente controlado com remember, e o layout foi estruturado com Column, OutlinedTextField, Button e TextButton para garantir responsividade e acessibilidade.

Com essa estrutura modular, o código está pronto para receber integrações futuras, como autenticação com backend ou Firebase. A separação clara dos composables facilita manutenção, testes e futuras melhorias no fluxo de autenticação. Essa atualização representa um avanço importante na base do aplicativo, alinhando o projeto com práticas recomendadas de desenvolvimento mobile.

![appmusculacao – MainActivity kt  appmusculacao app main  14_05_2025 11_43_42](https://github.com/user-attachments/assets/dbaf3ca6-5dd8-49d6-84ba-359fd584f6a3)


![appmusculacao – MainActivity kt  appmusculacao app main  14_05_2025 11_44_14](https://github.com/user-attachments/assets/a48d22df-0896-4160-bfc9-fe94fa7e63ec)
